### PR TITLE
add a build step to docker-compose

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,0 +1,3 @@
+#syntax=docker/dockerfile-upstream:latest
+
+FROM ghcr.io/hydrasco/hydra:latest

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following is a quick local setup. For production use, sign up for [our cloud
 
 ```console
 cp .env.example .env
+docker compose build --pull
 docker compose up
 psql postgres://postgres:hydra@127.0.0.1:5432
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   hydra:
     container_name: hydra
-    image: ghcr.io/hydrasco/hydra:latest
+    build:
+      dockerfile: ./Dockerfile.latest
+      context: .
     ports:
       - ${POSTGRES_PORT}:5432
     environment:


### PR DESCRIPTION
allows you to refresh the latest image without doing
`docker rmi`.